### PR TITLE
fix: ensure Japanese review request is consistently included in PR te…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- I want to review in Japanese. -->
+
 # 概要 & 関連資料
 <!-- issue番号を # の後に入れると PR merge 時に close される -->
 - close #
@@ -24,3 +26,5 @@
 
 # セルフチェック
 - [ ] 環境変数などがPRに含まれていないか
+
+<!-- I want to review in Japanese. -->


### PR DESCRIPTION
…mplate for Copilot
<!-- I want to review in Japanese. -->

# 概要 & 関連資料
<!-- issue番号を # の後に入れると PR merge 時に close される -->
- close #18 
- GitHub Copilot のレビューを日本語にする


# 変更内容
<!-- どのような変更をしたか -->
<!-- ex.) ユーザーがアプリを楽しく使えるようにタスク完了時にアニメーションをつけた -->

- ```.github/pull_request_template.md```の最初と最後に```<!-- I want to review in Japanese. -->```を書いた
- 参考: https://zenn.dev/gmomedia/articles/copilot-japanese-review-tips

# 影響範囲
<!-- どの画面に影響するか -->
<!-- ex.) タスク一覧画面 -->

- Pull Requestの際にCopilotが日本語でレビューしてくれる（？）

# 備考
<!-- レビューに関してのコメントなど -->
<!-- ex.) ダークモードへの対応はできてないが、後で対応するのでスルーして下さい -->
<!-- ex.) 動作確認のためには、.envにENV=trueを追記して下さい -->

- 英語のほうが好きな方がいたら教えてください。
- このプルリクの先頭と末尾に手動で```<!-- I want to review in Japanese. -->```と書いています
# セルフチェック
- [x] 環境変数などがPRに含まれていないか

<!-- I want to review in Japanese. -->
